### PR TITLE
Follow location

### DIFF
--- a/install-go.pl
+++ b/install-go.pl
@@ -232,13 +232,13 @@ sub install_go
 
     if ($EXT eq 'zip')
     {
-        exe(qw(curl -s -o x.zip), $url);
+        exe(qw(curl -L -s -o x.zip), $url);
         exe(qw(unzip x.zip go/bin/* go/pkg/* go/src/*));
         unlink 'x.zip';
     }
     else
     {
-        exe("curl -s \Q$url\E | tar zxf - go/bin go/pkg go/src");
+        exe("curl -L -s \Q$url\E | tar zxf - go/bin go/pkg go/src");
     }
 
     my $goroot_env;


### PR DESCRIPTION
This commit adds the `--location` flag to the curl calls as some packages seem to return a 302 currently due to the switch from golang.org > go.dev,