### PR TITLE
Improve windows support

### DIFF
--- a/install-go.pl
+++ b/install-go.pl
@@ -55,7 +55,7 @@ $DESTDIR = File::Spec::->rel2abs($DESTDIR);
 my($ARCH, $EXT) = ('amd64', 'tar.gz');
 my $OS;
 if ($^O eq 'linux' or $^O eq 'freebsd' or $^O eq 'darwin') { $OS = $^O }
-elsif ($^O eq 'msys' or $^O eq 'cygwin')
+elsif ($^O eq 'msys' or $^O eq 'cygwin' or $^O eq 'MSWin32')
 {
     $OS = 'windows';
     $EXT = 'zip';
@@ -233,7 +233,7 @@ sub install_go
     if ($EXT eq 'zip')
     {
         exe(qw(curl -L -s -o x.zip), $url);
-        exe(qw(unzip x.zip go/bin/* go/pkg/* go/src/*));
+        exe(qw(unzip x.zip go/bin/* go/pkg/**/* go/src/**/*));
         unlink 'x.zip';
     }
     else


### PR DESCRIPTION
It seems the unzip binary that comes with Git for Windows is slightly different from unzip on Linux and macOS. While I was using this `windows-latest`, this script would cause unzip to _only_ extract the files that are directly in the `go/pkg` and `go/src` dirs causing the sources of all built-in packages to be unavailable. This changes the call to recursively extract the files for those two dirs.

In addition `MSWin32` was added to the test for downloading the win binaries. This allows for the script to be run directly from PowerShell, at least on GitHub actions. It'll likely work everywhere as long as the curl/unzip (and other dependency) binaries are available in the PATH.